### PR TITLE
Minor patch for homebrew. There, the deploy runtime /opt/homebrew (ak…

### DIFF
--- a/tools/Makefile.common
+++ b/tools/Makefile.common
@@ -9,8 +9,10 @@ PERL = $(RUNTIME_BIN)/perl
 
 ifeq ($(KB_RUNTIME),/usr)
 TPAGE = tpage
-else
+else ifeq ($(HOMEBREW_FORMULA_PREFIX),,)
 TPAGE = $(RUNTIME_BIN)/tpage
+else
+TPAGE = $(HOMEBREW_FORMULA_PREFIX)/bin/tpage
 endif
 
 SERVICE_USER = kbase


### PR DESCRIPTION
…a $HOMEBREW_DEFAULT_PREFIX)

has perl, but the modules we are installing for the CLI are in $HOMEBREW_FORMULA_PREFIX